### PR TITLE
Added groovy backports to BuildConfig

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -54,7 +54,8 @@ grails.project.dependency.resolution = {
 
     neo4jVerison="2.0.3"
     dependencies {
-
+	//If using Groovy 2.4 uncomment the following line.
+	//compile 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'
         compile("org.neo4j:neo4j-community:$neo4jVerison")
 
         // this is required if DataSource.groovy uses url = "jdbc:neo4j:mem"


### PR DESCRIPTION
Added groovy backports dependency to successfully build the application on  Groovy >= Groovy 2.3.5. More detailed information can be found on the [Groovy mailing list](http://groovy.329449.n5.nabble.com/ANN-Groovy-2-3-5-released-and-upward-compatibility-td5720557.html).
